### PR TITLE
Fix unaligned load exception in simd4f_dot3.

### DIFF
--- a/include/vectorial/simd4f_sse.h
+++ b/include/vectorial/simd4f_sse.h
@@ -159,7 +159,7 @@ vectorial_inline simd4f simd4f_dot3(simd4f lhs,simd4f rhs) {
 #if defined(VECTORIAL_USE_SSE4_1)
     return _mm_dp_ps(lhs, rhs, 0x7f);
 #else
-    const unsigned int mask_array[] = { 0xffffffff, 0xffffffff, 0xffffffff, 0 };
+    simd4f_aligned16 const unsigned int mask_array[] = { 0xffffffff, 0xffffffff, 0xffffffff, 0 };
     const simd4f mask = _mm_load_ps((const float*)mask_array);
     const simd4f m = _mm_mul_ps(lhs, rhs);
     const simd4f s0 = _mm_and_ps(m, mask);


### PR DESCRIPTION
On non-SSE3 Intel processors, the `mask_array` pointer was not always
16-byte aligned, and this caused _mm_load_ps() to fail
(see https://msdn.microsoft.com/en-us/library/zzd50xxt(v=vs.90).aspx).

The fix is to always align this array using a compiler directive.

Tested: Bug was noticed on 32-bit x86 Android builds running on a
Nexus Player. Verified that the alignment directive fixes the crash.
